### PR TITLE
Export Counter and Gauge types

### DIFF
--- a/instrument.go
+++ b/instrument.go
@@ -4,36 +4,36 @@ import (
 	"sync/atomic"
 )
 
-type counter struct {
+type Counter struct {
 	value uint64
 }
 
-func (c *counter) Inc() {
+func (c *Counter) Inc() {
 	atomic.AddUint64(&c.value, 1)
 }
 
-func NewCounter(name string) *counter {
-	c := new(counter)
+func NewCounter(name string) *Counter {
+	c := new(Counter)
 	Publish(name, func() interface{} {
 		return c.value
 	})
 	return c
 }
 
-type gauge struct {
+type Gauge struct {
 	value int64
 }
 
-func (g *gauge) Inc() {
+func (g *Gauge) Inc() {
 	atomic.AddInt64(&g.value, 1)
 }
 
-func (g *gauge) Dec() {
+func (g *Gauge) Dec() {
 	atomic.AddInt64(&g.value, -1)
 }
 
-func NewGauge(name string) *gauge {
-	g := new(gauge)
+func NewGauge(name string) *Gauge {
+	g := new(Gauge)
 	Publish(name, func() interface{} {
 		return g.value
 	})


### PR DESCRIPTION
It seems like I can use these types anonymously with the := operator, but I can't put them into a struct to pass them around. It seems like it would be more useful to export the types. Unless I am missing something?
